### PR TITLE
Fix for docker

### DIFF
--- a/DsrProject/Systems/Api/DsrProject.Api/appsettings.json
+++ b/DsrProject/Systems/Api/DsrProject.Api/appsettings.json
@@ -23,11 +23,10 @@
   "Main": {
     "MainUrl": "http://localhost"
   },
-
-
+  
   "Database": {
     "Type": "PostgreSQL",
-    "ConnectionString": "Server=localhost;Port=5432;Database=DsrProject;User Id=postgres;Password=mdq082891;"
+    "ConnectionString": "Server=dsrproject_postgresql;Port=5432;Database=dsrDB;User Id=postgres;Password=passw0rd;"
   },
 
   "Swagger": {

--- a/DsrProject/docker-compose.override.yml
+++ b/DsrProject/docker-compose.override.yml
@@ -34,5 +34,4 @@ services:
 
 networks:
   shared_dsrproject_net:
-    name: dsr_net_project
     driver: bridge


### PR DESCRIPTION
For me API project didn't start
I used `docker-compose build` and then `docker-compose up`
Fixed db credentials in `appsettings.json` file, so now should be ok, but please check

Also can't access API from browser when running in docker. If you can - please attach a readme file with instructions
